### PR TITLE
Allow command-line arguments to be grouped in the usage.

### DIFF
--- a/src/main/java/com/fulcrumgenomics/sopt/cmdline/ArgAnnotation.java
+++ b/src/main/java/com/fulcrumgenomics/sopt/cmdline/ArgAnnotation.java
@@ -63,7 +63,7 @@ public @interface ArgAnnotation {
      * --help argument is specified.
      * @return Doc string associated with this command-line argument.
      */
-    String doc() default "Undocumented option";
+    String doc() default "Undocumented option.";
 
     /**
      * Array of option names that cannot be used in conjunction with this one.
@@ -98,4 +98,11 @@ public @interface ArgAnnotation {
      * for non-collection arguments.
      * */
     int maxElements() default Integer.MAX_VALUE;
+
+    /**
+     * The named group to which the command-line argument.  The group name can be any string, and the associated
+     * command-line arguments will be displayed in the help in a separate section from those without a group name (the
+     * empty string).
+     */
+    String group() default "";
 }

--- a/src/main/scala/com/fulcrumgenomics/sopt/cmdline/CommandLineParser.scala
+++ b/src/main/scala/com/fulcrumgenomics/sopt/cmdline/CommandLineParser.scala
@@ -39,24 +39,25 @@ import scala.reflect.runtime.universe._
 /** Various constants and methods for formatting and printing usages and error messages on the command line */
 trait CommandLineParserStrings {
   /** Lengths for names and descriptions on the command line */
-  val SubCommandGroupNameColumnLength = 38
-  val SubCommandGroupDescriptionColumnLength = Sopt.TerminalWidth - SubCommandGroupNameColumnLength
-  val SubCommandNameColumnLength = SubCommandGroupNameColumnLength - 3
+  val SubCommandGroupNameColumnLength: Int = 38
+  val SubCommandGroupDescriptionColumnLength: Int = Sopt.TerminalWidth - SubCommandGroupNameColumnLength
+  val SubCommandNameColumnLength: Int = SubCommandGroupNameColumnLength - 3
 
   /** The maximum line lengths for tool descriptions */
-  val SubCommandDescriptionLineLength = SubCommandGroupDescriptionColumnLength - 1
+  val SubCommandDescriptionLineLength: Int = SubCommandGroupDescriptionColumnLength - 1
 
   /** Error messages */
-  val AvailableSubCommands = "Available Sub-Commands:"
-  val MissingSubCommand = "No sub-command given."
+  val AvailableSubCommands: String = "Available Sub-Commands:"
+  val MissingSubCommand: String = "No sub-command given."
 
   /** Section headers */
-  val UsagePrefix = "USAGE:"
-  val RequiredArguments = "Required Arguments:"
-  val OptionalArguments = "Optional Arguments:"
+  val UsagePrefix: String = "USAGE:"
+  val ArgumentsSuffix: String = "Arguments:"
+  private[cmdline] val RequiredArguments: String = "Required Arguments:"
+  private[cmdline] val OptionalArguments: String = "Optional Arguments:"
 
   /** Section separator */
-  val SeparatorLine = KWHT("-" * Sopt.TerminalWidth + "\n")
+  val SeparatorLine: String = KWHT("-" * Sopt.TerminalWidth + "\n")
 
   /** Similarity floor for when searching for similar sub-command names. **/
   val HelpSimilarityFloor: Int = 7

--- a/src/test/scala/com/fulcrumgenomics/sopt/cmdline/ClpArgumentDefinitionPrintingTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sopt/cmdline/ClpArgumentDefinitionPrintingTest.scala
@@ -42,7 +42,7 @@ case object Whee extends Foo
   */
 class ClpArgumentDefinitionPrintingTest extends UnitSpec with BeforeAndAfterAll {
 
-  import com.fulcrumgenomics.sopt.cmdline.ClpArgumentDefinitionPrinting.makeDefaultValueString
+  import com.fulcrumgenomics.sopt.cmdline.ClpArgumentDefinitionPrinting.{makeDefaultValueString, ArgumentOptionalValue}
 
   private var printColor = true
 
@@ -56,21 +56,22 @@ class ClpArgumentDefinitionPrintingTest extends UnitSpec with BeforeAndAfterAll 
   }
 
   "ClpArgumentDefinitionPrinting.makeDefaultValueString" should "print the default value" in {
-    makeDefaultValueString(None) shouldBe ""
-    makeDefaultValueString(Some(None)) shouldBe ""
-    makeDefaultValueString(Some(Nil)) shouldBe ""
-    makeDefaultValueString(Some(Set.empty)) shouldBe ""
-    makeDefaultValueString(Some(new util.ArrayList[java.lang.Integer]())) shouldBe ""
-    makeDefaultValueString(Some(Some("Value"))) shouldBe "[Default: Value]."
-    makeDefaultValueString(Some("Value")) shouldBe "[Default: Value]."
-    makeDefaultValueString(Some(Some(Some("Value")))) shouldBe "[Default: Some(Value)]."
-    makeDefaultValueString(Some(List("A", "B", "C"))) shouldBe "[Default: A, B, C]."
+    makeDefaultValueString(None) shouldBe s"[[$ArgumentOptionalValue]]."
+    makeDefaultValueString(Some(None)) shouldBe s"[[$ArgumentOptionalValue]]."
+    makeDefaultValueString(Some(Nil)) shouldBe s"[[$ArgumentOptionalValue]]."
+    makeDefaultValueString(Some(Set.empty)) shouldBe s"[[$ArgumentOptionalValue]]."
+    makeDefaultValueString(Some(new util.ArrayList[java.lang.Integer]())) shouldBe s"[[$ArgumentOptionalValue]]."
+    makeDefaultValueString(Some(Some("Value"))) shouldBe "[[Default: Value]]."
+    makeDefaultValueString(Some("Value")) shouldBe "[[Default: Value]]."
+    makeDefaultValueString(Some(Some(Some("Value")))) shouldBe "[[Default: Some(Value)]]."
+    makeDefaultValueString(Some(List("A", "B", "C"))) shouldBe "[[Default: A, B, C]]."
   }
 
   private def printArgumentUsage(name: String, shortName: Option[Char], theType: String,
-                                 collectionDescription: Option[String], argumentDescription: String): String = {
+                                 collectionDescription: Option[String], argumentDescription: String,
+                                 optional: Boolean = false): String = {
     val stringBuilder = new StringBuilder
-    ClpArgumentDefinitionPrinting.printArgumentUsage(stringBuilder=stringBuilder, name, shortName, theType, collectionDescription, argumentDescription)
+    ClpArgumentDefinitionPrinting.printArgumentUsage(stringBuilder=stringBuilder, name, shortName, theType, collectionDescription, argumentDescription, optional)
     stringBuilder.toString
   }
 
@@ -82,7 +83,7 @@ class ClpArgumentDefinitionPrintingTest extends UnitSpec with BeforeAndAfterAll 
     val description = "Some description"
 
     printArgumentUsage(longName, shortName, theType,   None,           description).startsWith(s"-${shortName.get} $theType, --$longName=$theType") shouldBe true
-    printArgumentUsage(longName, shortName, "Boolean", None,           description).startsWith(s"-${shortName.get} [true|false], --$longName[=true|false]") shouldBe true
+    printArgumentUsage(longName, shortName, "Boolean", None,           description).startsWith(s"-${shortName.get} [[true|false]], --$longName[[=true|false]]") shouldBe true
     printArgumentUsage(longName, None     , theType,   None,           description).startsWith(s"--$longName=$theType") shouldBe true
     printArgumentUsage(longName, shortName, theType,   Some("+"),      description).startsWith(s"-${shortName.get} $theType+, --$longName=$theType+") shouldBe true
     printArgumentUsage(longName, shortName, theType,   Some("{0,20}"), description).startsWith(s"-${shortName.get} $theType{0,20}, --$longName=$theType{0,20}") shouldBe true

--- a/src/test/scala/com/fulcrumgenomics/sopt/cmdline/CommandLineParserTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sopt/cmdline/CommandLineParserTest.scala
@@ -34,6 +34,7 @@ import com.fulcrumgenomics.sopt._
 import com.fulcrumgenomics.sopt.cmdline.testing.clps._
 import com.fulcrumgenomics.sopt.util.UnitSpec
 import org.scalatest.{BeforeAndAfterAll, OptionValues}
+import com.fulcrumgenomics.sopt.cmdline.ClpArgumentDefinitionPrinting.ArgumentDefaultValuePrefix
 
 import scala.reflect.runtime.universe._
 import scala.reflect.ClassTag
@@ -47,8 +48,16 @@ class CommandLineProgramValidationError(@arg var aStringSomething: String = "Def
 class CommandLineParserTest extends UnitSpec with CaptureSystemStreams with BeforeAndAfterAll with OptionValues {
 
   private val prevPrintColor = TermCode.printColor
-  override protected def beforeAll(): Unit = TermCode.printColor = false
-  override protected def afterAll(): Unit = TermCode.printColor = prevPrintColor
+  private val prevIncludeRequiredAndOptionalSections = CommandLineProgramParserStrings.IncludeRequiredAndOptionalSections
+
+  override protected def beforeAll(): Unit = {
+    TermCode.printColor = false
+    CommandLineProgramParserStrings.IncludeRequiredAndOptionalSections = true
+  }
+  override protected def afterAll(): Unit = {
+    TermCode.printColor = prevPrintColor
+    CommandLineProgramParserStrings.IncludeRequiredAndOptionalSections = prevIncludeRequiredAndOptionalSections
+  }
 
   private def nameOf(clazz: Class[_]): String = clazz.getSimpleName
 


### PR DESCRIPTION
@tfenne I am open to the formatting of the "group name" in the usage.  I have not implemented support for a description for each group; I am leaving that for latter if needed (I don't need it)

Commit message:

> The @arg annotation has a "group" member that can be set.  Leaving it
> blank (an empty string) will cause it to be part of the default group,
> and listed at the top of the usage.  The groups are then displayed in
> the usage in alphabetical order, with sections for required and optional
> command-line arguments for each group.

From the tests, this class:
```
@clp(description = "", group = classOf[TestGroup], hidden = true)
private case class MultipleGroupNames
(
  @arg(group="1") oneRequired: Int,
  @arg(group="1") oneOptional: Option[Int] = None,
  @arg(group="2") twoRequired: Int,
  @arg(group="3") threeOptional: Int = 1,
  @arg noGroup: Int = 3
)
```

gives this usage:

```
USAGE: MultipleGroupNames [arguments]
------------------------------------------------------------------------------------------------------------------------


MultipleGroupNames Optional Arguments:
------------------------------------------------------------------------------------------------------------------------
--no-group=Int                Undocumented option Default: 3.

MultipleGroupNames (1) Required Arguments:
------------------------------------------------------------------------------------------------------------------------
--one-required=Int            Undocumented option

MultipleGroupNames (1) Optional Arguments:
------------------------------------------------------------------------------------------------------------------------
--one-optional=Int            Undocumented option

MultipleGroupNames (2) Required Arguments:
------------------------------------------------------------------------------------------------------------------------
--two-required=Int            Undocumented option

MultipleGroupNames (3) Optional Arguments:
------------------------------------------------------------------------------------------------------------------------
--three-optional=Int          Undocumented option Default: 1.