### PR TITLE
Bug fix: short name for the conflicting option improperly formatted

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/sopt/cmdline/ClpArgumentDefinitionPrinting.scala
+++ b/src/main/scala/com/fulcrumgenomics/sopt/cmdline/ClpArgumentDefinitionPrinting.scala
@@ -84,10 +84,10 @@ object ClpArgumentDefinitionPrinting {
       sb.append(argumentDefinition.mutuallyExclusive.map { targetFieldName =>
         argumentLookup.forField(targetFieldName) match {
           case None =>
-            throw new UserException(s"Invalid argument definition in source code (see mutex). " +
+            throw UserException(s"Invalid argument definition in source code (see mutex). " +
               s"$targetFieldName doesn't match any known argument.")
           case Some(mutex) =>
-            mutex.name + (if (mutex.shortName.nonEmpty) s" (${mutex.shortName})" else "")
+            mutex.name + mutex.shortName.map { c => s" ($c)" }.getOrElse("")
         }
       }.mkString(", "))
     }


### PR DESCRIPTION
Always displayed `Some(_)` since we didn't get the value in the `Option`.