### PR TITLE
Word wrapping could trim off trailing ANSI terminal codes.

### DIFF
--- a/src/test/scala/com/fulcrumgenomics/sopt/util/MarkDownProcessorTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sopt/util/MarkDownProcessorTest.scala
@@ -205,4 +205,18 @@ class MarkDownProcessorTest extends UnitSpec {
     val html = processor.toHtml(processor.parse(markdown)).trim
     html shouldBe expected
   }
+
+  "MarkDownProcessor.trim" should "trim the first non-ansi-escape-code non-whitespace characters" in {
+    MarkDownProcessor.trim(KRED(KGRN(" A BCDEF G"))) shouldBe KRED(KGRN("A BCDEF G"))
+    MarkDownProcessor.trim(KRED(KGRN("A BCDEF G"))) shouldBe KRED(KGRN("A BCDEF G"))
+    MarkDownProcessor.trim(KRED(" ABCDEFG")) shouldBe KRED("ABCDEFG")
+    MarkDownProcessor.trim(" ABCDEFG") shouldBe "ABCDEFG"
+  }
+
+  it should "trim the last non-ansi-escape-code whitespace characters" in {
+    MarkDownProcessor.trim(KRED(KGRN("A BCDEF G "))) shouldBe KRED(KGRN("A BCDEF G"))
+    MarkDownProcessor.trim(KRED(KGRN("A BCDEF G"))) shouldBe KRED(KGRN("A BCDEF G"))
+    MarkDownProcessor.trim(KRED("ABCDEFG ")) shouldBe KRED("ABCDEFG")
+    MarkDownProcessor.trim("ABCDEFG ") shouldBe "ABCDEFG"
+  }
 }

--- a/src/test/scala/com/fulcrumgenomics/sopt/util/MarkDownProcessorTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sopt/util/MarkDownProcessorTest.scala
@@ -1,7 +1,5 @@
 package com.fulcrumgenomics.sopt.util
 
-import com.fulcrumgenomics.commons.CommonsDef._
-
 class MarkDownProcessorTest extends UnitSpec {
   val processor = new MarkDownProcessor()
 
@@ -177,7 +175,19 @@ class MarkDownProcessorTest extends UnitSpec {
 
     proc.toText(proc.parse(markdown)) shouldBe markdown.lines.toSeq
   }
-  
+
+  "MarkDownProcessor.toText" should "convert markdown to text ignoring trailing terminal codes" in {
+    val proc = new MarkDownProcessor(lineLength=40)
+    val sb = new StringBuilder()
+    sb.append(KGRN("--remove-alignment-information[[=true|false]]"))
+    sb.append(" ")
+    sb.append(KCYN("Remove all alignment information (as well as secondary and supplementary records. " + KGRN("[[Default: false]].")))
+    val markdown = KCYN(sb.toString)
+    val lines = proc.toText(proc.parse(markdown))
+    val processedMarkdown = markdown.replaceAll("\\[\\[", "[").replaceAll("\\]\\]", "]")
+    lines.mkString(" ") shouldBe processedMarkdown
+  }
+
   "MarkDownProcessor.toHtml" should "convert markdown to HTML" in {
     val markdown =
       """


### PR DESCRIPTION
It looks like [`trim()](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#trim--) will remove our ANSI color codes:

> Otherwise, if there is no character with a code greater than '\u0020' in the string, then a String object representing an empty string is returned.
> 
> Otherwise, let k be the index of the first character in the string whose code is greater than '\u0020', and let m be the index of the last character in the string whose code is greater than '\u0020'. A String object is returned, representing the substring of this string that begins with the character at index k and ends with the character at index m-that is, the result of this.substring(k, m + 1)

Fixes: https://github.com/fulcrumgenomics/sopt/issues/14