### PR TITLE
Use green as the color for possible values.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/sopt/cmdline/ClpArgumentDefinitionPrinting.scala
+++ b/src/main/scala/com/fulcrumgenomics/sopt/cmdline/ClpArgumentDefinitionPrinting.scala
@@ -76,7 +76,7 @@ object ClpArgumentDefinitionPrinting {
     val sb: StringBuilder = new StringBuilder
     if (argumentDefinition.doc.nonEmpty) sb.append(argumentDefinition.doc).append("  ")
     if (argumentDefinition.optional) sb.append(makeDefaultValueString(argumentDefinition.defaultValue))
-    val possibles = possibleValues(argumentDefinition.unitType)
+    val possibles = KGRN(possibleValues(argumentDefinition.unitType))
     if (possibles.nonEmpty) sb.append(" ").append(possibles)
 
     if (argumentDefinition.mutuallyExclusive.nonEmpty) {


### PR DESCRIPTION
Previously, they defaulted to the terminal color.

I found this during debugging another PR.