### PR TITLE
Chain error messages for better debugging of incorrect argument values.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/sopt/cmdline/ClpReflectiveBuilder.scala
+++ b/src/main/scala/com/fulcrumgenomics/sopt/cmdline/ClpReflectiveBuilder.scala
@@ -173,7 +173,7 @@ private[sopt] class ClpArgument(declaringClass: Class[_],
       ReflectionUtil.constructFromString(this.argumentType, this.unitType, values: _*) match {
         case Success(v) => v
         case Failure(ex: Exception) => throw BadArgumentValue(
-          msg="Argument could not be constructed from string" + chainedExceptionMessage(ex))
+          msg=s"Argument '$longName' could not be constructed from string" + chainedExceptionMessage(ex))
         case Failure(thr) => throw BadArgumentValue(thr.getMessage)
       }
     }

--- a/src/main/scala/com/fulcrumgenomics/sopt/cmdline/ClpReflectiveBuilder.scala
+++ b/src/main/scala/com/fulcrumgenomics/sopt/cmdline/ClpReflectiveBuilder.scala
@@ -172,12 +172,18 @@ private[sopt] class ClpArgument(declaringClass: Class[_],
     else this.value = {
       ReflectionUtil.constructFromString(this.argumentType, this.unitType, values: _*) match {
         case Success(v) => v
-        case Failure(ex: Exception) => throw new BadArgumentValue(msg="Argument could not be constructed from string", e=ex)
+        case Failure(ex: Exception) => throw BadArgumentValue(
+          msg="Argument could not be constructed from string" + chainedExceptionMessage(ex))
         case Failure(thr) => throw BadArgumentValue(thr.getMessage)
       }
     }
 
     this.isSetByUser = true
+  }
+
+  /** Creates a single message from the chain of exceptions starting at ex. */
+  private def chainedExceptionMessage(ex: Throwable): String = {
+    if (ex == null) "" else s"\n\t...${ex.getMessage}" + chainedExceptionMessage(ex.getCause)
   }
 
   /** Gets the list of names by which this option can be passed on the command line. Will be length 1 or 2. */

--- a/src/test/scala/com/fulcrumgenomics/sopt/cmdline/ClpReflectiveBuilderTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sopt/cmdline/ClpReflectiveBuilderTest.scala
@@ -117,6 +117,7 @@ class ClpReflectiveBuilderTest extends UnitSpec {
     val exception = intercept[Exception] { arg.setArgument("NotALogLevel") }
     exception.getMessage.count(_ == '\n') should be > 0 // At least two lines, from a chained exception
     // make sure all enums are listed
+    exception.getMessage should include ("log-level")
     LogLevel.values().foreach { level => exception.getMessage should include (level.name()) }
   }
 


### PR DESCRIPTION
Motivation was to have better messages when mis-specifying enum values.