### PR TITLE
Sort enum values alphabetically for help descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
+# IDE specific
+*.iml
 .idea
-target
+
+# Build tool specific
+out/
+target/

--- a/src/main/scala/com/fulcrumgenomics/sopt/cmdline/ClpArgumentDefinitionPrinting.scala
+++ b/src/main/scala/com/fulcrumgenomics/sopt/cmdline/ClpArgumentDefinitionPrinting.scala
@@ -178,7 +178,7 @@ object ClpArgumentDefinitionPrinting {
         case Success(constants) => constants
         case Failure(thr) => throw thr
       }
-      enumConstants.map(_.name).mkString(EnumOptionDocPrefix, ", ", EnumOptionDocSuffix)
+      enumConstants.map(_.name).sorted.mkString(EnumOptionDocPrefix, ", ", EnumOptionDocSuffix)
     }
     else {
       val symbol = scala.reflect.runtime.currentMirror.classSymbol(clazz)

--- a/src/test/scala/com/fulcrumgenomics/sopt/cmdline/CommandLineProgramParserTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sopt/cmdline/CommandLineProgramParserTest.scala
@@ -677,11 +677,16 @@ with CommandLineParserStrings with CaptureSystemStreams with BeforeAndAfterAll {
       .foreach(str => str.endsWith("argument=String") shouldBe false)
   }
 
-  it should "print enum values in the  usage" in {
+  it should "print enum values in the usage" in {
     val usage = parser(classOf[GoodEnumClass]).usage(withVersion = false, withSpecial = false)
-    GoodEnum.values.foreach(e =>
-      usage should include (e.name())
+    GoodEnum.values.foreach( e =>
+      e.name.r.findAllIn(usage).length shouldBe 1
     )
+  }
+
+  it should "print enum values in sorted order" in {
+    val usage: String = parser(classOf[GoodEnumClass]).usage(withVersion = false, withSpecial = false)
+    GoodEnum.values.map(_.toString).sorted.map(usage.indexOf) shouldBe sorted
   }
 
   it should "throw an exception when an enum has no values" in {


### PR DESCRIPTION
Enums rendered with `sopt` have never been in written or sorted orders.

Although enums defined with `Enumeratum` should be in written-order:

> Note that by default, findValues will return a Seq with the enum members listed in written-order (relevant if you want to use the indexOf method).

I have a feeling this bit of code bypasses the `findValues` macro, but my scala-foo is not strong enough to debug further.

https://github.com/fulcrumgenomics/sopt/blob/3a8fb76ca4f48ccc5116e9cd02378519e7e93412/src/main/scala/com/fulcrumgenomics/sopt/cmdline/ClpArgumentDefinitionPrinting.scala#L177-L181

In the meantime, will you accept this PR and let my weary eyes read alphabetically sorted enums?