### PR TITLE
Add NO_COLOR support and Version result type

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/sopt/Sopt.scala
+++ b/src/main/scala/com/fulcrumgenomics/sopt/Sopt.scala
@@ -26,6 +26,8 @@ object Sopt {
   case class SubcommandSuccess[A,B](command: A, subcommand: B) extends Result[A, B]
   /** The result type when a parsing failure occurrs. */
   case class Failure(usage: () => String) extends Result[Nothing,Nothing]
+  /** The result type when --version was requested (not a failure). */
+  case class Version(version: () => String) extends Result[Nothing,Nothing]
 
   protected trait MarkDownDescription {
     /** The description as MarkDown text. */

--- a/src/main/scala/com/fulcrumgenomics/sopt/cmdline/CommandLineParser.scala
+++ b/src/main/scala/com/fulcrumgenomics/sopt/cmdline/CommandLineParser.scala
@@ -26,7 +26,7 @@ package com.fulcrumgenomics.sopt.cmdline
 
 import com.fulcrumgenomics.commons.CommonsDef._
 import com.fulcrumgenomics.commons.reflect.ReflectionUtil
-import com.fulcrumgenomics.sopt.Sopt.{CommandSuccess, Failure, Result, SubcommandSuccess}
+import com.fulcrumgenomics.sopt.Sopt.{CommandSuccess, Failure, Result, SubcommandSuccess, Version}
 import com.fulcrumgenomics.sopt.{Sopt, clp}
 import com.fulcrumgenomics.sopt.util.ParsingUtil._
 import com.fulcrumgenomics.sopt.util._
@@ -320,8 +320,7 @@ class CommandLineParser[SubCommand](val commandLineName: String)
             print(clpParser.usage(withVersion=withVersion))
             Failure(() => usagePrinter.toString())
           case ParseVersion()  => // Case 7
-            print(clpParser.version)
-            Failure(() => usagePrinter.toString())
+            Version(() => clpParser.version)
           case ParseSuccess() => // Case 8
             val clp: SubCommand = clpParser.instance.get
             try {
@@ -400,8 +399,7 @@ class CommandLineParser[SubCommand](val commandLineName: String)
         print(subCommandListUsage(subcommands, commandLineName, withPreamble=true))
         Failure(() => usagePrinter.toString())
       case ParseVersion() => // Case (3)
-        print(mainClassParser.version)
-        Failure(() => usagePrinter.toString())
+        Version(() => mainClassParser.version)
       case ParseSuccess() => // Case (4-8)
         /////////////////////////////////////////////////////////////////////////
         // Get setup, and attempt to ID and load the clp class
@@ -411,6 +409,7 @@ class CommandLineParser[SubCommand](val commandLineName: String)
 
         this.parseSubCommand(args=clpArgs, subcommands=subcommands, extraUsage = Some(mainClassParser.usage()), withVersion=false) match {
           case f: Failure          => f
+          case v: Version          => v
           case CommandSuccess(sub) => SubcommandSuccess(mainInstance, sub)
           case other               => unreachable("Why did parseSubCommand return " + other)
         }

--- a/src/main/scala/com/fulcrumgenomics/sopt/util/TermCode.scala
+++ b/src/main/scala/com/fulcrumgenomics/sopt/util/TermCode.scala
@@ -25,8 +25,8 @@
 package com.fulcrumgenomics.sopt.util
 
 object TermCode  {
-  /** True if we are to use ANSI colors to print to the terminal, false otherwise. */
-  var printColor: Boolean = true
+  /** True to use ANSI colors, false otherwise. Respects NO_COLOR env var per no-color.org. */
+  var printColor: Boolean = Option(System.getenv("NO_COLOR")).forall(_.isEmpty)
 }
 
 /** Base class for all terminal codes (ex ANSI colors for terminal output).  The apply method applies the code to the

--- a/src/test/scala/com/fulcrumgenomics/sopt/cmdline/CommandLineParserTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sopt/cmdline/CommandLineParserTest.scala
@@ -27,7 +27,7 @@ package com.fulcrumgenomics.sopt.cmdline
 import com.fulcrumgenomics.commons.CommonsDef._
 import com.fulcrumgenomics.commons.reflect.ReflectionUtil
 import com.fulcrumgenomics.commons.util.CaptureSystemStreams
-import com.fulcrumgenomics.sopt.Sopt.{CommandSuccess, Failure, SubcommandSuccess}
+import com.fulcrumgenomics.sopt.Sopt.{CommandSuccess, Failure, SubcommandSuccess, Version}
 import com.fulcrumgenomics.sopt.{Sopt, _}
 import com.fulcrumgenomics.sopt.cmdline.testing.clps._
 import com.fulcrumgenomics.sopt.util.{TermCode, UnitSpec}
@@ -71,6 +71,7 @@ class CommandLineParserTest extends UnitSpec with CaptureSystemStreams with Befo
       result match {
         case CommandSuccess(command) => (parser, Some(command), "")
         case Failure(usage)          => (parser, None, usage())
+        case Version(version)        => (parser, None, version())
         case other                   => unreachable(s"Should not have matched: $other")
       }
     }
@@ -204,6 +205,7 @@ class CommandLineParserTest extends UnitSpec with CaptureSystemStreams with Befo
       parser.parseCommandAndSubCommand[Command](args, subcommands) match {
         case SubcommandSuccess(cmd, sub) => (parser, Some(cmd), Some(sub), "")
         case Failure(usage)              => (parser, None, None, usage())
+        case Version(version)            => (parser, None, None, version())
         case other                       => unreachable(s"Should not have gotten $other")
       }
     }
@@ -529,5 +531,29 @@ class CommandLineParserTest extends UnitSpec with CaptureSystemStreams with Befo
     testSplitArgs(Seq[String](nameOf(classOf[CommandLineProgramOne])), 0, 1)
     testSplitArgs(Seq[String]("blah", nameOf(classOf[CommandLineProgramOne])), 1, 1)
     testSplitArgs(Seq[String]("blah", nameOf(classOf[CommandLineProgramOne]), "blah"), 1, 2)
+  }
+
+  "CommandLineParser.parseSubCommand" should "return Version result when --version is given after clp name" in {
+    val parser = new CommandLineParser[TestingClp]("test")
+    val subcommands = Sopt.find[TestingClp](TestParseSubCommand.packageList, includeHidden = true)
+    Seq("-v", "--version").foreach { arg =>
+      parser.parseSubCommand(Seq(nameOf(classOf[CommandLineProgramOne]), arg), subcommands) match {
+        case Version(versionFn) =>
+          versionFn() should include("Version:")
+        case other => fail(s"Expected Version but got $other")
+      }
+    }
+  }
+
+  "CommandLineParser.parseCommandAndSubCommand" should "return Version result when --version is given before clp name" in {
+    val parser = new CommandLineParser[TestingClp]("test")
+    val subcommands = Sopt.find[TestingClp](TestParseSubCommand.packageList, includeHidden = true)
+    Seq("-v", "--version").foreach { arg =>
+      parser.parseCommandAndSubCommand[CommandLineProgramTesting](Seq(arg), subcommands) match {
+        case Version(versionFn) =>
+          versionFn() should include("Version:")
+        case other => fail(s"Expected Version but got $other")
+      }
+    }
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/sopt/util/TermCodeTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sopt/util/TermCodeTest.scala
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2015-2016 Fulcrum Genomics LLC
+ * Copyright (c) 2026 Fulcrum Genomics LLC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/scala/com/fulcrumgenomics/sopt/util/TermCodeTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sopt/util/TermCodeTest.scala
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015-2016 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.sopt.util
+
+class TermCodeTest extends UnitSpec {
+  "TermCode" should "allow printColor to be toggled" in {
+    val original = TermCode.printColor
+    try {
+      TermCode.printColor = true
+      KRED("test") should include("\u001B[31m")
+
+      TermCode.printColor = false
+      KRED("test") shouldBe "test"
+    } finally {
+      TermCode.printColor = original
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- TermCode now respects the `NO_COLOR` environment variable per [no-color.org](https://no-color.org/) standard
- New `Sopt.Version` result type distinguishes version requests from failures, allowing callers to output version to stdout with exit code 0

## Breaking Change

The new `Version` result type is a source-breaking change. Existing consumers with `match` expressions on `Result` will need to add a case:

```scala
case Sopt.Version(version) =>
  System.out.println(version())
  0
```

This is intentional to ensure consumers handle version output correctly (stdout, exit 0).

## Test plan

- [x] All existing tests pass
- [x] New `TermCodeTest` verifies `printColor` toggling behavior
- [x] New tests verify `Version` result type is returned for `--version` flag
- [x] Manual verification: `NO_COLOR=1` disables colored output

Addresses fulcrumgenomics/fgbio#1131