### PR TITLE
Prevent release job from being cancelled by subsequent pushes

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -105,7 +105,7 @@ jobs:
         shell: bash -l {0}
         run: |
           echo "$PGP_SECRET" | base64 --decode | gpg --import --batch --yes
-      - name: Build and sign artifacts
+      - name: Build, sign, and publish artifacts
         shell: bash -l {0}
         run: |
-          sbt +publishSigned
+          sbt +publishSigned sonatypeCentralUpload

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     concurrency:
-      group: test-${{ github.workflow }}-${{ github.ref }}
+      group: test-${{ github.workflow }}-${{ github.ref }}-${{ matrix.jvm }}
       cancel-in-progress: true
     strategy:
       matrix:

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -12,13 +12,12 @@ on:
       SONATYPE_PASS:
         required: false
 
-concurrency:
-  group: unittest-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   test:
     runs-on: ubuntu-latest
+    concurrency:
+      group: test-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     strategy:
       matrix:
         jvm: ["temurin:1.8.0-442", "temurin:1.11.0.27", "temurin:1.17.0.15", "temurin:1.21.0.7", "temurin:1.22.0.2"]
@@ -57,6 +56,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     environment: github-actions
+    concurrency:
+      group: release-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: false
     env:
       SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
       SONATYPE_PASS: ${{ secrets.SONATYPE_PASS }}


### PR DESCRIPTION
## Summary
- Move concurrency settings from workflow level to job level
- Test jobs can still be cancelled when new pushes arrive (saves CI resources)
- Release jobs now have `cancel-in-progress: false` to ensure releases complete

## Background
During the 1.2.0 release, the release job was cancelled when the follow-up snapshot version commit was pushed too quickly. This change ensures release jobs always complete.

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Future releases will complete even if follow-up commits are pushed