### PR TITLE
build: bump flexmark to 0.64.8 (and scalatest to 3.2.20)

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -39,7 +39,7 @@ jobs:
           sbt clean coverage test
           sbt coverageReport coverageAggregate
       - name: Code Coverage
-        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d  # v5.4.2
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests # optional

--- a/build.sbt
+++ b/build.sbt
@@ -144,10 +144,11 @@ lazy val root = Project(id="sopt", base=file("."))
     libraryDependencies ++= Seq(
       "org.scala-lang"       %  "scala-reflect" %  scalaVersion.value,
       "com.fulcrumgenomics"  %% "commons"       % "1.6.0",
-      "com.vladsch.flexmark" % "flexmark"       % "0.18.5",
+      "com.vladsch.flexmark" % "flexmark"       % "0.64.8",
 
       //---------- Test libraries -------------------//
-      "org.scalatest"             %% "scalatest"     % "3.1.3"  % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")
+      "org.scalatest"             %% "scalatest"     % "3.2.20" % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit"),
+      "com.vladsch.flexmark"      %  "flexmark-all"  % "0.64.8" % "test" // for ScalaTest's HtmlReporter (-h test option)
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -144,11 +144,11 @@ lazy val root = Project(id="sopt", base=file("."))
     libraryDependencies ++= Seq(
       "org.scala-lang"       %  "scala-reflect" %  scalaVersion.value,
       "com.fulcrumgenomics"  %% "commons"       % "1.6.0",
-      "com.vladsch.flexmark" % "flexmark"       % "0.64.8",
+      "com.vladsch.flexmark" % "flexmark"       % "0.62.2", // 0.62.2 is the last release built for JDK 8; 0.64+ requires JDK 11
 
       //---------- Test libraries -------------------//
       "org.scalatest"             %% "scalatest"     % "3.2.20" % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit"),
-      "com.vladsch.flexmark"      %  "flexmark-all"  % "0.64.8" % "test" // for ScalaTest's HtmlReporter (-h test option)
+      "com.vladsch.flexmark"      %  "flexmark-all"  % "0.62.2" % "test" // for ScalaTest's HtmlReporter (-h test option)
     )
   )
 

--- a/src/main/scala/com/fulcrumgenomics/sopt/util/MarkDownProcessor.scala
+++ b/src/main/scala/com/fulcrumgenomics/sopt/util/MarkDownProcessor.scala
@@ -27,7 +27,8 @@ package com.fulcrumgenomics.sopt.util
 import com.vladsch.flexmark.ast._
 import com.vladsch.flexmark.html.HtmlRenderer
 import com.vladsch.flexmark.parser.{Parser, ParserEmulationProfile}
-import com.vladsch.flexmark.util.options.MutableDataSet
+import com.vladsch.flexmark.util.ast.{Document, Node}
+import com.vladsch.flexmark.util.data.MutableDataSet
 
 import scala.collection.mutable.ListBuffer
 import com.fulcrumgenomics.commons.CommonsDef._

--- a/src/test/scala/com/fulcrumgenomics/sopt/util/UnitSpec.scala
+++ b/src/test/scala/com/fulcrumgenomics/sopt/util/UnitSpec.scala
@@ -23,7 +23,8 @@
  */
 package com.fulcrumgenomics.sopt.util
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /** Base class for unit and integration testing */
-class UnitSpec extends FlatSpec with Matchers
+class UnitSpec extends AnyFlatSpec with Matchers


### PR DESCRIPTION
## Summary
- Bump flexmark `0.18.5` → `0.62.2` — the latest flexmark release still built for JDK 8 (0.64.0+ retargeted to JDK 11, which breaks our `temurin:1.8.0-442` CI job).
- Bump scalatest `3.1.3` → `3.2.20` in lockstep: 3.1.3's `HtmlReporter` references `com.vladsch.flexmark.Extension`, which lived in the package root in flexmark ≤ 0.35.10 and was removed in 0.42.x — it cannot coexist with modern flexmark.
- Add `flexmark-all` `0.62.2` in test scope: scalatest 3.2.x's `HtmlReporter` extracted its Pegdown adapter into `flexmark-all` (the runtime error from scalatest explicitly says to add it).
- Bump `codecov/codecov-action` `v5.4.2` → `v5.5.4` (SHA-pinned) to satisfy the org policy on full-SHA-pinned action transitives — 5.4.x's `action.yml` had `uses: actions/github-script@v7` unpinned.

Source changes are limited to import updates:
- `Document` / `Node` moved from `flexmark.ast` → `flexmark.util.ast`
- `MutableDataSet` moved from `flexmark.util.options` → `flexmark.util.data`
- `FlatSpec` / `Matchers` moved into per-style subpackages in scalatest 3.2 (`AnyFlatSpec`, `matchers.should.Matchers`)

## Test plan
- [x] `sbt test` — 250/250 pass locally (JDK 17)
- [x] `sbt doc` — succeeds
- [x] `sbt clean coverage test coverageReport` — succeeds (92.38% / 92.59%)
- [ ] CI: unit tests on JDKs 8/11/17/21/22